### PR TITLE
Markdown analysis report garbled issue

### DIFF
--- a/toolbox.py
+++ b/toolbox.py
@@ -49,7 +49,7 @@ def write_results_to_file(history, file_name=None):
     if file_name is None:
         file_name = time.strftime("chatGPT分析报告%Y-%m-%d-%H-%M-%S", time.localtime()) + '.md'
     os.makedirs('./gpt_log/', exist_ok=True)
-    with open(f'./gpt_log/{file_name}', 'w') as f:
+    with open(f'./gpt_log/{file_name}', 'w', encoding = 'utf8') as f:
         f.write('# chatGPT 分析报告\n')
         for i, content in enumerate(history):
             if i%2==0: f.write('## ')


### PR DESCRIPTION
When writing to a file, the default ANSI encoding is used, while most developers are not familiar with ANSI encoding and most tools read Markdown files in UTF-8 encoding by default, causing garbled text when reading the analysis report. I have specified UTF-8 encoding in the writing section of the code and request to submit a pull request.