### PR TITLE
version error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gradio>=3.23
+gradio>=3.22
 requests[socks]
 mdtex2html


### PR DESCRIPTION
在国内经常使用的清华源上目前还没有gradio的最新版本（ 3.23），3.22版本也可以使用。

清华源最新版本3.22.1
![image](https://user-images.githubusercontent.com/20925537/228578629-44fd116f-133b-4c20-a07d-9a4d73d1ba83.png)
