### PR TITLE
feat: clean pdf fitz text

### DIFF
--- a/crazy_functions/批量总结PDF文档.py
+++ b/crazy_functions/批量总结PDF文档.py
@@ -1,5 +1,5 @@
 from predict import predict_no_ui
-from toolbox import CatchException, report_execption, write_results_to_file, predict_no_ui_but_counting_down
+from toolbox import CatchException, report_execption, write_results_to_file, predict_no_ui_but_counting_down, clean_text
 fast_debug = False
 
 
@@ -11,6 +11,7 @@ def 解析PDF(file_manifest, project_folder, top_p, temperature, chatbot, histor
             file_content = ""
             for page in doc:
                 file_content += page.get_text()
+            file_content = clean_text(file_content)
             print(file_content)
 
         prefix = "接下来请你逐文件分析下面的论文文件，概括其内容" if index==0 else ""

--- a/toolbox.py
+++ b/toolbox.py
@@ -236,3 +236,59 @@ def clear_line_break(txt):
     txt = txt.replace('  ', ' ')
     txt = txt.replace('  ', ' ')
     return txt
+
+import re
+import unicodedata
+
+def is_paragraph_break(match):
+    """
+    根据给定的匹配结果来判断换行符是否表示段落分隔。
+    如果换行符前为句子结束标志（句号，感叹号，问号），且下一个字符为大写字母，则换行符更有可能表示段落分隔。
+    也可以根据之前的内容长度来判断段落是否已经足够长。
+    """
+    prev_char, next_char = match.groups()
+
+    # 句子结束标志
+    sentence_endings = ".!?"
+
+    # 设定一个最小段落长度阈值
+    min_paragraph_length = 140
+
+    if prev_char in sentence_endings and next_char.isupper() and len(match.string[:match.start(1)]) > min_paragraph_length:
+        return "\n\n" 
+    else:
+        return " "
+
+def normalize_text(text):
+    """
+    通过把连字（ligatures）等文本特殊符号转换为其基本形式来对文本进行归一化处理。
+    例如，将连字 "fi" 转换为 "f" 和 "i"。
+    """
+    # 对文本进行归一化处理，分解连字
+    normalized_text = unicodedata.normalize("NFKD", text)
+
+    # 替换其他特殊字符
+    cleaned_text = re.sub(r'[^\x00-\x7F]+', '', normalized_text)
+
+    return cleaned_text
+
+def clean_text(raw_text):
+    """
+    对从 PDF 提取出的原始文本进行清洗和格式化处理。
+    1. 对原始文本进行归一化处理。
+    2. 替换跨行的连词，例如 “Espe-\ncially” 转换为 “Especially”。
+    3. 根据 heuristic 规则判断换行符是否是段落分隔，并相应地进行替换。
+    """
+    # 对文本进行归一化处理
+    normalized_text = normalize_text(raw_text)
+
+    # 替换跨行的连词
+    text = re.sub(r'(\w+-\n\w+)', lambda m: m.group(1).replace('-\n', ''), normalized_text)
+
+    # 根据前后相邻字符的特点，找到原文本中的换行符
+    newlines = re.compile(r'(\S)\n(\S)')
+
+    # 根据 heuristic 规则，用空格或段落分隔符替换原换行符
+    final_text = re.sub(newlines, lambda m: m.group(1) + is_paragraph_break(m) + m.group(2), text)
+
+    return final_text.strip()


### PR DESCRIPTION
This commit adds a script that cleans up PDF file to a plain text with improved paragraph detection. The script cleans up the ligatures problem of the fitz library for PDF processing with unicodedata for character normalization.

In addition to the basic text extraction, the script applies heuristic rules to preprocess the text for improved paragraph detection. Specifically, it replaces period + '\n' + Capital letter with period + Capital letter and requires at least two sentences for a paragraph separation.