### PR TITLE
feat: 使用CSS完善表格、列表、代码块、对话气泡显示样式

### DIFF
--- a/theme.py
+++ b/theme.py
@@ -83,15 +83,23 @@ def adjust_theme():
 
 advanced_css = """
 .markdown-body table {
-    border: 1px solid #ddd; 
+    margin: 1em 0;
     border-collapse: collapse;
+    empty-cells: show;
 }
-
 .markdown-body th, .markdown-body td {
-    border: 1px solid #ddd; 
+    border: 1.2px solid var(--border-color-primary);
     padding: 5px;
 }
+.markdown-body thead {
+    background-color: rgba(175,184,193,0.2);
+}
+.markdown-body thead th {
+    padding: .5em .2em;
+}
+
 # 以下 CSS 来自对 https://github.com/GaiZhenbiao/ChuanhuChatGPT 的移植。
+
 /* list */
 ol:not(.options), ul:not(.options) {
     padding-inline-start: 2em !important;
@@ -115,22 +123,6 @@ ol:not(.options), ul:not(.options) {
     width: auto !important;
     border-bottom-right-radius: 0 !important;
 }
-/* 表格 
-table {
-    margin: 1em 0;
-    border-collapse: collapse;
-    empty-cells: show;
-}
-td,th {
-    border: 1.2px solid var(--border-color-primary) !important;
-    padding: 0.2em;
-}
-thead {
-    background-color: rgba(175,184,193,0.2);
-}
-thead th {
-    padding: .5em .2em;
-} */
 /* 行内代码 */
 code {
     display: inline;

--- a/theme.py
+++ b/theme.py
@@ -91,4 +91,63 @@ advanced_css = """
     border: 1px solid #ddd; 
     padding: 5px;
 }
+# 以下 CSS 来自对 https://github.com/GaiZhenbiao/ChuanhuChatGPT 的移植。
+/* list */
+ol:not(.options), ul:not(.options) {
+    padding-inline-start: 2em !important;
+}
+/* 对话气泡 */
+[class *= "message"] {
+    border-radius: var(--radius-xl) !important;
+    padding: var(--spacing-xl) !important;
+    font-size: var(--text-md) !important;
+    line-height: var(--line-md) !important;
+    min-height: calc(var(--text-md)*var(--line-md) + 2*var(--spacing-xl));
+    min-width: calc(var(--text-md)*var(--line-md) + 2*var(--spacing-xl));
+}
+[data-testid = "bot"] {
+    max-width: 85%;
+    width: auto !important;
+    border-bottom-left-radius: 0 !important;
+}
+[data-testid = "user"] {
+    max-width: 85%;
+    width: auto !important;
+    border-bottom-right-radius: 0 !important;
+}
+/* 表格 
+table {
+    margin: 1em 0;
+    border-collapse: collapse;
+    empty-cells: show;
+}
+td,th {
+    border: 1.2px solid var(--border-color-primary) !important;
+    padding: 0.2em;
+}
+thead {
+    background-color: rgba(175,184,193,0.2);
+}
+thead th {
+    padding: .5em .2em;
+} */
+/* 行内代码 */
+code {
+    display: inline;
+    white-space: break-spaces;
+    border-radius: 6px;
+    margin: 0 2px 0 2px;
+    padding: .2em .4em .1em .4em;
+    background-color: rgba(175,184,193,0.2);
+}
+/* 代码块 */
+pre code {
+    display: block;
+    overflow: auto;
+    white-space: pre;
+    background-color: rgba(175,184,193,0.2);
+    border-radius: 10px;
+    padding: 1em;
+    margin: 1em 2em 1em 0.5em;
+}
 """


### PR DESCRIPTION
（前面写了封email提过hhh，现在我来提pr了）

### What's Changed

- 增加了更多CSS来控制输出样式:
   - 有序与无序列表：现在是正确的缩进，不会左边出头；
   - 行内代码和代码块：有了底色；
   - 对话气泡：比gradio的精致了，现在气泡随内容多少自适应宽度，同时用户的文字靠右对齐；
- 本来表格也想直接写我们的，才发现刚刚有人写过了，就整合了下：
   - 现在边框没那么突兀了……

| **before** | **after** |
|----|----|
|<img width="846" alt="image" src="https://user-images.githubusercontent.com/23137268/229280968-01033b6d-45ac-4062-9efc-7230a470378d.png"><img width="849" alt="image" src="https://user-images.githubusercontent.com/23137268/229280979-7482563b-7f37-4067-b41f-fc86c323466c.png">|<img width="845" alt="image" src="https://user-images.githubusercontent.com/23137268/229281007-197e38b0-9c6b-429d-aac8-daa9180b0a61.png"><img width="851" alt="image" src="https://user-images.githubusercontent.com/23137268/229281020-c4e7074c-c1b2-40e8-b152-434af53a15f7.png">|

### 说明

- 移植了 [川虎ChatGPT](https://github.com/GaiZhenbiao/ChuanhuChatGPT) 的CSS —— 不过那里也是我写的CSS，所以我自己提交pr应该不会产生著作权纠纷（
- 我们在川虎ChatGPT做了代码高亮，所以代码块底色比较黑，但这里为了避免太多变化就只给了个灰底，应该还行。如果想改都可以找我。
- 我们自己当时也遇到过的问题：Gradio自己更新之后改了CSS变量的命名方式导致CSS失效，需要跟上脚步更改新的CSS变量名……就很离谱，它们并不向下兼容。所以希望gradio不要再改变量名了。
- 其他 UI 样式不太清楚你们的想法，我就先不动啦。其实gradio原生也还可以的~


