### PR TITLE
使用代理的问题

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pymupdf
 openai
 numpy
 python-docx
+urllib3==1.25.11


### PR DESCRIPTION
在使用原来的requirement装了相关包之后，使用代理会出现
```
(chat) PS C:\Users\Misaki\Desktop\z\chatgpt_academic> python .\check_proxy.py
[PROXY] 网络代理状态：已配置。配置信息如下： {'http': 'http://127.0.0.1:4780', 'https': 'https://127.0.0.1:4780'}
代理配置 https://127.0.0.1:4780, 代理所在地查询超时，代理可能无效
```

然后通过`test_proxy.py`:
```python
import requests

proxies = {'http': 'http://127.0.0.1:4780', 'https': 'https://127.0.0.1:4780'}
response = requests.get("https://ipapi.co/json/", proxies=proxies, timeout=4, verify=False)
```

报错:
```
Traceback (most recent call last):
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\requests\adapters.py", line 489, in send
    resp = conn.urlopen(
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\urllib3\connectionpool.py", line 755, in urlopen
    retries = retries.increment(
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\urllib3\util\retry.py", line 573, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='ipapi.co', port=443): Max retries exceeded with url: /json/ (Caused by ProxyError('Cannot connect to proxy.', FileNotFoundError(2, 'No such file or directory')))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\Misaki\Desktop\z\chatgpt_academic\test_proxy.py", line 5, in <module>
    response = requests.get("https://ipapi.co/json/", proxies=proxies, timeout=4, verify=False)
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\requests\api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\requests\api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\requests\sessions.py", line 587, in request
    resp = self.send(prep, **send_kwargs)
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\requests\sessions.py", line 701, in send
    r = adapter.send(request, **kwargs)
  File "C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\requests\adapters.py", line 559, in send
    raise ProxyError(e, request=request)
requests.exceptions.ProxyError: HTTPSConnectionPool(host='ipapi.co', port=443): Max retries exceeded with url: /json/ (Caused by ProxyError('Cannot connect to proxy.', FileNotFoundError(2, 'No such file or directory')))
```

将`urllib3`降级之后 代理配置成功
```
pip install urllib3==1.25.11 -i https://mirrors.aliyun.com/pypi/simple/
```

再次运行`test_proxy.py`
```
(chat) PS C:\Users\Misaki\Desktop\z\chatgpt_academic> python .\test_proxy.py
C:\Users\Misaki\miniconda3\envs\chat\lib\site-packages\urllib3\connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host '127.0.0.1'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```

