### PR TITLE
[fix]Update requirements.txt For fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gradio>=3.23
+gradio>=3.25.0
 requests[socks]
 transformers
 python-markdown-math


### PR DESCRIPTION
Modify the version of Gradio, which does not support the color button when it is lower than version 3.24. On version 3.25, it fixes the issue https://github.com/gradio-app/gradio/issues/3716 and #371 .

修改一下gradio的版本，低于 3.24版本时不支持 color button，3.25则修复了 issue: #371 和 https://github.com/gradio-app/gradio/issues/3716